### PR TITLE
Update Tween to include more parameters

### DIFF
--- a/source/tween.js
+++ b/source/tween.js
@@ -23,8 +23,10 @@ Habitat = {}
 	Habitat.Tween.EASE_IN_EXP = Habitat.Tween.EASE_IN_EXPONENTIAL = (e) => (t) => Math.pow(2, e*t - e) * t
 	Habitat.Tween.EASE_OUT_EXP = Habitat.Tween.EASE_OUT_EXPONENTIAL = (e) => (t) => 1 - Math.pow(2, -e*t) * (1-t)
 	Habitat.Tween.EASE_IN_OUT_EXP = Habitat.Tween.EASE_IN_OUT_EXPONENTIAL = (e) => (t) => {
-		if (t < 0.5) return Math.pow(2, 2*e*t - e)/2
-		return (2 - Math.pow(2, -2*e*t + e))/2
+		let f;
+		if (t < 0.5) f = t => Math.pow(2, 2*e*t - e)/2
+		else f = t => (2 - Math.pow(2, -2*e*t + e))/2
+		return f(t) * ((1-t)*f(0) + t*(f(1)-1))
 	}
 	Habitat.Tween.EASE_IN_CIRCULAR = (t) => 1 - Math.sqrt(1 - Math.pow(t, 2))
 	Habitat.Tween.EASE_OUT_CIRCULAR = (t) => Math.sqrt(1 - Math.pow(t - 1, 2))

--- a/source/tween.js
+++ b/source/tween.js
@@ -1,14 +1,69 @@
 //=======//
 // Tween //
 //=======//
+
+Habitat = {}
+
 {
 	Habitat.Tween = {}
+	
+	// all from https://easings.net
+	Habitat.Tween.EASE_IN_LINEAR = (t) => t
+	Habitat.Tween.EASE_OUT_LINEAR = (t) => t
+	Habitat.Tween.EASE_IN_OUT_LINEAR = (t) => t
+	Habitat.Tween.EASE_IN_SINE = (t) => 1-Math.cos(t*Math.PI/2)
+	Habitat.Tween.EASE_OUT_SINE = (t) => Math.sin(t*Math.PI/2)
+	Habitat.Tween.EASE_IN_OUT_SINE = (t) => -(Math.cos(t*Math.PI)-1)/2
+	Habitat.Tween.EASE_IN_POWER = (p) => (t) => Math.pow(t, p)
+	Habitat.Tween.EASE_OUT_POWER = (p) => (t) => 1-Math.pow(1-t, p)
+	Habitat.Tween.EASE_IN_OUT_POWER = (p) => (t) => {
+		if (t < 0.5) return Math.pow(2, p-1)*Math.pow(t, p)
+		return 1 - Math.pow(2 - 2*t, p)/2
+	}
+	Habitat.Tween.EASE_IN_EXP = Habitat.Tween.EASE_IN_EXPONENTIAL = (e) => (t) => Math.pow(2, e*t - e) * t
+	Habitat.Tween.EASE_OUT_EXP = Habitat.Tween.EASE_OUT_EXPONENTIAL = (e) => (t) => 1 - Math.pow(2, -e*t) * (1-t)
+	Habitat.Tween.EASE_IN_OUT_EXP = Habitat.Tween.EASE_IN_OUT_EXPONENTIAL = (e) => (t) => {
+		if (t < 0.5) return Math.pow(2, 2*e*t - e)/2
+		return (2 - Math.pow(2, -2*e*t + e))/2
+	}
+	Habitat.Tween.EASE_IN_CIRCULAR = (t) => 1 - Math.sqrt(1 - Math.pow(t, 2))
+	Habitat.Tween.EASE_OUT_CIRCULAR = (t) => Math.sqrt(1 - Math.pow(t - 1, 2))
+	Habitat.Tween.EASE_IN_OUT_CIRCULAR = (t) => {
+		if (t < 0.5) return 0.5 - Math.sqrt(1 - Math.pow(2*t, 2))/2
+		return 0.5 + Math.sqrt(1 - Math.pow(-2*t + 2, 2))/2
+	}
+	Habitat.Tween.EASE_IN_BACK = (t) => 2.70158*t*t*t - 1.70158*t*t
+	Habitat.Tween.EASE_OUT_BACK = (t) => 1 + 2.70158*Math.pow(t - 1, 3) + 1.70158*Math.pow(t - 1, 2)
+	Habitat.Tween.EASE_IN_OUT_BACK = (t) => {
+		if (t < 0.5) return (Math.pow(2*t, 2)*(3.59491*2*t - 2.59491))/2
+		return (Math.pow(2*t-2,2)*(3.59491*(t*2-2) + 2.59491)+2)/2
+	}
+	Habitat.Tween.EASE_IN_ELASTIC = (t) => -Math.pow(2,10*t-10)*Math.sin((t*10-10.75)*2*Math.PI/3)
+	Habitat.Tween.EASE_OUT_ELASTIC = (t) => Math.pow(2,-10*t)*Math.sin((t*10-0.75)*2*Math.PI/3)+1
+	Habitat.Tween.EASE_IN_OUT_ELASTIC = (t) => {
+		if (t < 0.5) return -(Math.pow(2, 20*t-10)*Math.sin((20*t-11.125)*2*Math.PI/4.5))/2
+		return (Math.pow(2, -20*t+10)*Math.sin((20*t-11.125)*2*Math.PI/4.5))/2+1
+	}
+	Habitat.Tween.EASE_OUT_BOUNCE = (t) => (t) => {
+		const n1 = 7.5625
+		const d1 = 2.75
+
+		if      (t < 1 / d1)   return n1 * t * t
+		else if (t < 2 / d1)   return n1 * (t -= 1.5 / d1) * t + 0.75
+		else if (t < 2.5 / d1) return n1 * (t -= 2.25 / d1) * t + 0.9375
+		else                   return n1 * (t -= 2.625 / d1) * t + 0.984375
+	}
+	Habitat.Tween.EASE_IN_BOUNCE = (t) => 1-Habitat.Tween.EASE_OUT_BOUNCE(1-t)
+	Habitat.Tween.EASE_IN_OUT_BOUNCE = (t) => {
+		if (t < 0.5) return (1-Habitat.Tween.EASE_OUT_BOUNCE(1-2*t))/2
+		return (1+Habitat.Tween.EASE_OUT_BOUNCE(2*t-1))/2
+	}
 
 	Habitat.Tween.install = (global) => {
 		Habitat.Tween.installed = true
 
 		Reflect.defineProperty(global.Object.prototype, "tween", {
-			value(propertyName, {to, from, over = 1000, launch = 0.5, land = 0.5, ease=false} = {}) {
+			value(propertyName, {to, from, over = 1000, launch = 0.5, land = 0.5, strength = 1, ease = false} = {}) {
 				const before = this[propertyName]
 				if (from === undefined) from = before
 				if (to === undefined) to = before
@@ -30,61 +85,18 @@
 								enumerable: true
 							})
 							return to
-						} else {
-							const t = (now - start) / over
-							if (typeof ease == 'function') return ease(t) * (to - from) + from
-							if (typeof ease == 'string') {
-								// all from https://easings.net
-								let ob = (t) => {
-									const n1 = 7.5625
-									const d1 = 2.75
-									
-									if      (t < 1 / d1)   return n1 * t * t
-									else if (t < 2 / d1)   return n1 * (t -= 1.5 / d1) * t + 0.75
-									else if (t < 2.5 / d1) return n1 * (t -= 2.25 / d1) * t + 0.9375
-									else                   return n1 * (t -= 2.625 / d1) * t + 0.984375
-								}
-								let easefuncs = {
-									easeinlinear: t => t,
-									easeoutlinear: t => t,
-									easeinoutlinear: t => t,
-									easeinsine: t => 1-Math.cos(t*Math.PI/2),
-									easeoutsine: t => Math.sin(t*Math.PI/2),
-									easeinoutsine: t => -(Math.cos(t*Math.PI)-1)/2,
-									easeinquadratic: t => Math.pow(t,2),
-									easeoutquadratic: t => 1-Math.pow(1-t,2),
-									easeinoutquadratic: t => t<0.5 ? 2*t*t : 1-Math.pow(-2*t+2,2)/2,
-									easeincubic: t => Math.pow(t,3),
-									easeoutcubic: t => 1-Math.pow(1-t,3),
-									easeinoutcubic: t => t<0.5 ? 4*t*t*t : 1-Math.pow(-2*t+2,3)/2,
-									easeinquartic: t => Math.pow(t,4),
-									easeoutquartic: t => 1-Math.pow(1-t,4),
-									easeinoutquartic: t => t<0.5 ? 8*t*t*t*t : 1-Math.pow(-2*t+2,4)/2,
-									easeinquintic: t => Math.pow(t,5),
-									easeoutquintic: t => 1-Math.pow(1-t,5),
-									easeinoutquintic: t => t<0.5 ? 16*t*t*t*t*t : 1-Math.pow(-2*t+2,5)/2,
-									easeinexponential: t => t==0 ? 0 : Math.pow(2,10*t-10),
-									easeoutexponential: t => t==1 ? 1 : 1-Math.pow(2,-10*t),
-									easeinoutexponential: t => t==0 ? 0 : t==1 ? 1 : t<0.5 ? Math.pow(2,20*t-10)/2 : (2-Math.pow(2,-20*t+10))/2,
-									easeincircular: t => 1-Math.sqrt(1-Math.pow(t,2)),
-									easeoutcircular: t => Math.sqrt(1-Math.pow(t-1,2)),
-									easeinoutcircular: t => t<0.5 ? (1-Math.sqrt(1-Math.pow(2*t,2)))/2 : (Math.sqrt(1-Math.pow(-2*t+2,2))+1)/2,
-									easeinback: t => 2.70158*t*t*t-1.70158*t*t,
-									easeoutback: t => 1+2.70158*Math.pow(t-1,3)+1.70158*Math.pow(t-1,2),
-									easeinoutback: t => t<0.5 ? (Math.pow(2*t,2)*((3.59491)*2*t-2.59491))/2 : (Math.pow(2*t-2,2)*((3.59491)*(t*2-2)+2.59491)+2)/2,
-									easeinelastic: t => t==0 ? 0 : t==1 ? 1 : -Math.pow(2,10*t-10)*Math.sin((t*10-10.75)*2*Math.PI/3),
-									easeoutelastic: t => t==0 ? 0 : t==1 ? 1 : Math.pow(2,-10*t)*Math.sin((t*10-0.75)*2*Math.PI/3)+1,
-									easeinoutelastic: t => t==0 ? 0 : t==1 ? 1 : t<0.5 ? -(Math.pow(2,20*t-10)*Math.sin((20*t-11.125)*2*Math.PI/4.5))/2 : (Math.pow(2,-20*t+10)*Math.sin((20*t-11.125)*2*Math.PI/4.5))/2+1,
-									easeinbounce: t => 1-ob(1-t),
-									easeoutbounce: ob,
-									easeinoutbounce: t => t<0.5 ? (1-ob(1-2*t))/2 : (1+ob(2*t-1))/2
-								}
-								if (Object.keys(easefuncs).includes(ease.toLowerCase()))
-									return easefuncs[ease.toLowerCase()](t) * (to - from) + from
-							}
-							const v = 3*t*(1-t)*(1-t)*launch + 3*t*t*(1-t)*land + t*t*t
-							return v * (to - from) + from
 						}
+
+						const t = (now - start) / over
+
+						if (ease) {
+							const v = ease(strength)
+							if (typeof v == 'function') return v(t) * (to - from) + from
+							return ease(t) * (to - from) + from
+						}
+
+						const v = 3*t*(1-t)*(1-t)*launch + 3*t*t*(1-t)*land + t*t*t
+						return v * (to - from) + from
 
 					},
 					set() { },

--- a/source/tween.js
+++ b/source/tween.js
@@ -2,8 +2,6 @@
 // Tween //
 //=======//
 
-Habitat = {}
-
 {
 	Habitat.Tween = {}
 	


### PR DESCRIPTION
`ease` (expects a fuction that returns a value, or a fuction that returns a function that returns a value)
- Specifies the type of easing to use, built in ease types include `Tween.EASE_IN_SINE`, `Tween.EASE_OUT_CIRCULAR`, or even `Tween.EASE_IN_OUT_POWER`
- In the case of `Tween.EASE_..._POWER` and `Tween.EASE_..._EXPONENTIAL` (or just `Tween.EASE_..._EXP`), you can specify a strength parameter as if it were a function; `Tween.EASE_..._POWER(3)` would be the same as Cubic Tweening, _or_ you can use the `strength` parameter, it works exactly the same.

I plan on adding support for number of bounces in `Tween.EASE_..._BOUNCE`, as well as dampening for `Tween.EASE_..._ELASTIC`, but idk how to do that yet lol